### PR TITLE
Add StarDict downloads

### DIFF
--- a/content/downloads/contents.lr
+++ b/content/downloads/contents.lr
@@ -11,6 +11,19 @@ to target different dictionary applications, also referred to as platforms.
 The advantage of this approach is that the dictionary data can be used for any
 application and that you can pick what suits you best.
 
+## StarDict: Common Choice for Most Devices
+
+The dictionaries in StarDict format can be used with a wide variety of different dictionary applications, e.g.:
+
+* [GoldenDict](http://goldendict.org/) for Linux, Windows
+* [GoldenDict mobile](http://goldendict.mobi/) for Android (non-free)
+* [WordMateX](https://play.google.com/store/apps/details?id=org.d1scw0rld.wordmatex&hl=en) for Android (non-free)
+* [Dictionary Universal](https://apps.apple.com/us/app/dictionary-universal/id312088272) for iOS (non-free)
+* [KOReader](https://github.com/koreader/koreader) for a variety of e-readers and Android devices
+
+---
+after_stardict:
+
 ## Slob: Smartphones And Tablets
 
 For smartphones and tablets, our dictionaries are available in the

--- a/content/downloads/contents.lr
+++ b/content/downloads/contents.lr
@@ -11,7 +11,7 @@ to target different dictionary applications, also referred to as platforms.
 The advantage of this approach is that the dictionary data can be used for any
 application and that you can pick what suits you best.
 
-## Smartphones And Tablets
+## Slob: Smartphones And Tablets
 
 For smartphones and tablets, our dictionaries are available in the
 [slob format](https://github.com/itkach/slob/wiki/Dictionaries),
@@ -25,7 +25,7 @@ Finally, download one of our dictionaries below to your smartphone.
 ---
 after_mobile:
 
-## Computers
+## Dictd: Computers
 
 For desktop computers, you are free to choose between a variety of dictionary
 programs, a selection of clients can be found on our

--- a/models/downloads.ini
+++ b/models/downloads.ini
@@ -12,6 +12,11 @@ label = Body
 type = markdown
 translate = True
 
+[fields.after_stardict]
+label = Body
+type = markdown
+translate = True
+
 [fields.after_mobile]
 label = Body
 type = markdown

--- a/packages/freedict/lektor_freedict.py
+++ b/packages/freedict/lektor_freedict.py
@@ -104,11 +104,6 @@ def mk_dropdown(dictionaries, codes, platform):
 
 def generate_download_section(target):
     """Target can be either 'mobile' or 'desktop'."""
-    platforms = {'mobile': 'slob', 'desktop': 'dictd', 'source': 'src'}
-    if not target in platforms:
-        raise ValueError("Expected either mobile or desktop as target, got " + \
-                repr(target))
-
     setup_gettext()
     json_api = load_json_api()
     codes = load_iso_table()
@@ -119,11 +114,13 @@ def generate_download_section(target):
         if not 'releases' in dictionary: # not a dictionary, skip
             continue
         try:
-            url = next(r for r in dictionary['releases'] if r['platform'] ==
-                    platforms[target])['URL']
+            url = next(
+                    r for r in dictionary['releases']
+                    if r['platform'] == target
+                  )['URL']
         except StopIteration:
             raise ValueError("Dictionary %s without release for %s" % (
-                dictionary['name'], platforms[target]))
+                dictionary['name'], target))
         name = dictionary['name']
         dictionaries[name] = {'url': url, 'edition': dictionary['edition'],
                 'headwords': dictionary['headwords'],

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -43,15 +43,15 @@ function showDictionaries(e, platform) {
 
   {{ super() }}
 
-{{ generate_download_section('mobile') }}
+{{ generate_download_section('slob') }}
 
 {{ this.after_mobile }}
 
-{{ generate_download_section('desktop') }}
+{{ generate_download_section('dictd') }}
 
 {% block after_desktop %} {{ this.after_desktop }} {% endblock %}
 
-{{ generate_download_section('source') }}
+{{ generate_download_section('src') }}
 
 {% block after_source %} {{ this.after_source }} {% endblock %}
 <script>

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -43,9 +43,13 @@ function showDictionaries(e, platform) {
 
   {{ super() }}
 
+{{ generate_download_section('stardict') }}
+
+{% block after_stardict %} {{ this.after_stardict }} {% endblock %}
+
 {{ generate_download_section('slob') }}
 
-{{ this.after_mobile }}
+{% block after_mobile %} {{ this.after_mobile }} {% endblock %}
 
 {{ generate_download_section('dictd') }}
 


### PR DESCRIPTION
This PR tries to add support for StarDict downloads while minimizing changes.

Changes:
* Prefix existing sections with the format
* Remove abstraction target->platform (it adds more confusion than benefit IMO)
* Add new section with StarDict format

Potential followups:
- [ ] Check text on download website for consistency and accuracy after this change
- [ ] Optionally rename old sections in code to the format names for consistency (mobile -> slob)
- [ ] Update translations after text changes (esp. the new stardict section is completely missing translations)